### PR TITLE
fix(app): add keys property to ApiKeyListResponse type

### DIFF
--- a/apps/app/app/(dev-console)/dev-console/api-keys/api-keys-client.tsx
+++ b/apps/app/app/(dev-console)/dev-console/api-keys/api-keys-client.tsx
@@ -46,6 +46,7 @@ interface ApiKeyListResponse {
   success: boolean;
   result?: { apiKeys: ApiKey[] };
   apiKeys?: ApiKey[];
+  keys?: ApiKey[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the pre-existing TypeScript error blocking CI:

```
app/(dev-console)/dev-console/api-keys/api-keys-client.tsx(660,65): error TS2339:
Property 'keys' does not exist on type 'ApiKeyListResponse'.
```

## Root cause

The API route `GET /api/settings/api-keys` returns `{ keys: [...] }` (line 48 of the API route handler). The client already handles this shape at runtime via the fallback chain:

```ts
const keys = data.result?.apiKeys ?? data.apiKeys ?? data.keys ?? [];
```

But the `ApiKeyListResponse` interface was missing the `keys` property, causing `tsc` to fail.

## Change

Added `keys?: ApiKey[]` to `ApiKeyListResponse` — one line.

## Validation

- `pnpm --filter app typecheck` passes with zero errors.