### PR TITLE
perf(turbo): tighten cache keys + enable typecheck caching

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -87,6 +87,20 @@
     },
     "build": {
       "dependsOn": ["^build", "generate"],
+      "env": [
+        "NEXT_PUBLIC_*",
+        "BASEHUB_TOKEN",
+        "CLERK_SECRET_KEY"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/__tests__/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.spec.ts",
+        "!**/*.spec.tsx"
+      ],
       "outputs": [
         ".next/**",
         "!.next/cache/**",
@@ -101,7 +115,14 @@
     },
     "typecheck": {
       "dependsOn": ["^typecheck"],
-      "cache": false
+      "inputs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.d.ts",
+        "tsconfig*.json",
+        "package.json"
+      ],
+      "outputs": []
     },
     "lint": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
## Summary

Three targeted improvements to \`turbo.json\` that meaningfully increase cache hit rates and make builds reproducible.

### Changes

**1. `build` task — declared `env` list**
\`\`\`json
"env": ["NEXT_PUBLIC_*", "BASEHUB_TOKEN", "CLERK_SECRET_KEY"]
\`\`\`
These vars get baked into Next.js bundles at build time. Previously they were in \`globalPassThroughEnv\` (passed through but not part of the cache key), meaning a change to \`NEXT_PUBLIC_APP_URL\` would silently serve a stale cached build with the old URL. Now those vars properly invalidate the cache.

**2. `build` task — declared `inputs`**
\`\`\`json
"inputs": [
  "$TURBO_DEFAULT$",
  "!**/*.md", "!**/__tests__/**",
  "!**/*.test.ts", "!**/*.test.tsx",
  "!**/*.spec.ts", "!**/*.spec.tsx"
]
\`\`\`
Markdown and test files no longer invalidate the build cache. Doc-only PRs become free.

**3. `typecheck` task — enabled caching**
\`\`\`json
"typecheck": {
  "dependsOn": ["^typecheck"],
  "inputs": ["**/*.ts", "**/*.tsx", "**/*.d.ts", "tsconfig*.json", "package.json"],
  "outputs": []
}
\`\`\`
Was \`cache: false\`. Pre-commit hooks and CI runs both run typecheck across 28 packages (~40s each time). With caching, no-source-change runs become near-instant.

## Verification

Tested with two consecutive builds on \`--filter=./apps/api --filter=./apps/app --filter=./apps/web\`:

| Metric | Before | After |
|---|---|---|
| Cache hits on no-source-change rebuild | 0/12 | 5/7 cached (filtered) |
| Wall time | 1m17 | 50s |
| Typecheck cacheable? | No | Yes |

## Known follow-up (not in this PR)

The three Next.js app builds (\`apps/api#build\`, \`apps/app#build\`, \`apps/web#build\`) still report **cache miss despite identical input hashes**. Verified via:
- \`turbo build --dry-run=json\` reports \`"status": "HIT", "source": "LOCAL"\` with full cache time-savings
- Same actual \`turbo build\` invocation reports \`cache miss, executing\` and reruns

The cache file exists on disk (50 MB \`.tar.zst\` with correct hash), the metadata matches, and input fingerprints are identical between consecutive runs. Restarting the turbo daemon doesn't help. Tested with and without \`signature: true\`.

This looks like a turbo bug (likely interaction between Turbopack-generated output filenames containing \`[...]\` and Windows tar extraction). Worth a separate investigation + upstream issue. Doesn't regress anything — those apps weren't caching before either.

## Test plan

- [x] \`pnpm turbo build --filter=./apps/api --filter=./apps/app --filter=./apps/web\` passes
- [x] Cache hit rate on rebuild verified above
- [x] Pre-commit typecheck still passes (it runs the new cacheable typecheck task)
- [ ] Vercel preview build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)