### PR TITLE
[chore] track Manifest dev-tooling (.vscode/extensions.json + .husky/pre-commit)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,16 @@
+# Manifest pre-commit hook (U16/U18): when .manifest source is staged, enforce
+# formatting and validation before the commit lands. No-op when no .manifest
+# files are staged so non-manifest commits stay fast.
+staged_manifests=$(git diff --cached --name-only --diff-filter=ACM -- '*.manifest')
+
+if [ -n "$staged_manifests" ]; then
+  echo "manifest pre-commit: formatting + validating staged .manifest files…"
+  pnpm manifest:fmt:check || {
+    echo "✗ manifest formatting check failed — run 'pnpm manifest:fmt' and re-stage."
+    exit 1
+  }
+  pnpm manifest:validate || {
+    echo "✗ manifest validation failed."
+    exit 1
+  }
+fi

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "angriff36.manifest-lang",
+    "biomejs.biome"
+  ]
+}


### PR DESCRIPTION
Closes the U14/U16/U18 gap: these files were authored but gitignored (`.vscode/` and `/.husky/` are dir-ignored as local-only), so they never shipped through the repo.

- `.vscode/extensions.json` — recommends `angriff36.manifest-lang` + `biomejs.biome`
- `.husky/pre-commit` — format-checks + validates staged `*.manifest` files (no-op otherwise); marked executable

`.vscode/settings.json` is intentionally left ignored — the on-disk copy holds machine-specific absolute paths (`C:\Users\...`) that must not be committed.

Branch is cut from current `main` (includes the D16 `manifest:ci` repair).