### PR TITLE
[fix] bump manifest to 2.7.0 + drop dead U6 shard check

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pdf-parse": "^2.4.5"
   },
   "devDependencies": {
-    "@angriff36/manifest": "2.5.1",
+    "@angriff36/manifest": "2.7.0",
     "@auto-it/first-time-contributor": "^11.3.6",
     "@babel/parser": "^7.29.7",
     "@biomejs/biome": "2.4.15",


### PR DESCRIPTION
**Why:** capsule's source uses cross-file `mixin TenantScoped` (101 files), which only compiles on `@angriff36/manifest >= 2.6.0`. The root `package.json` still pinned `2.5.1` (lockfile + other pins were already 2.7.0), so a stale install compiled on 2.5.1 and the full 103-file `compileProjectToIR` failed with `mixes unknown entity 'TenantScoped'`.

**Fix:** bump the root pin to `2.7.0`. With 2.7.0 installed, the full compile passes and `manifest:verify-invariants` is green.

**Also:** removed the dead U6 shard-read check in `verify-invariants.mjs`. The real U6 proof is already Group C (full compile = zero errors → every cross-file mixin resolved; merged IR has one tenant). The shard read claimed "compiles cleanly" while compiling nothing — it could read green even when the real compile fails. Gate is now 22/22, honestly.

Verified locally: `pnpm install` → manifest 2.7.0 → `pnpm manifest:verify-invariants` = 22/22.